### PR TITLE
chore: refactor fns to utilize latest go SDK offerings

### DIFF
--- a/functions/Func_Jobs/api/handler.go
+++ b/functions/Func_Jobs/api/handler.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
+	"github.com/crowdstrike/gofalcon/falcon"
+	"github.com/crowdstrike/gofalcon/falcon/client"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
+)
+
+func NewHandler(cfg models.Config) func(context.Context, *slog.Logger, fdk.SkipCfg) fdk.Handler {
+	falconClientMW := withFalconClient(cfg.Cloud)
+	return func(context.Context, *slog.Logger, fdk.SkipCfg) fdk.Handler {
+		mux := fdk.NewMux()
+		mux.Get("/audits", falconClientMW(fdk.HandlerFn(auditHandlerFn)))
+		mux.Get("/job", falconClientMW(fdk.HandlerFn(handleSaveJobVersion)))
+		mux.Get("/jobs", falconClientMW(fdk.HandlerFn(handleAppJobDetails)))
+		mux.Put("/upsert-job", falconClientMW(handleUpsertJob(cfg)))
+		return mux
+	}
+}
+
+type ctxKey string
+
+const ctxKeyFalconClient ctxKey = "falcon_client"
+
+func withFalconClient(cloud falcon.CloudType) func(fdk.Handler) fdk.Handler {
+	return func(next fdk.Handler) fdk.Handler {
+		return fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+			fc, err := models.FalconClient(ctx, cloud, r.AccessToken)
+			if err != nil {
+				return fdk.ErrResp(fdk.APIError{Code: http.StatusBadRequest, Message: "failed to initialize client"})
+			}
+
+			ctx = context.WithValue(ctx, ctxKeyFalconClient, fc)
+
+			return next.Handle(ctx, r)
+		})
+	}
+}
+
+func getFalconClient(ctx context.Context) *client.CrowdStrikeAPISpecification {
+	fc, _ := ctx.Value(ctxKeyFalconClient).(*client.CrowdStrikeAPISpecification)
+	return fc
+}

--- a/functions/Func_Jobs/api/job.go
+++ b/functions/Func_Jobs/api/job.go
@@ -2,86 +2,40 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
 	"github.com/crowdstrike/gofalcon/falcon/client"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
-const queryIDParam = "id"
-
-// JobHandler executes a given request to the FaaS function.
-type JobHandler struct {
-	conf *models.Config
-}
-
-// NewJobHandler returns an initialized version of JobHandler.
-func NewJobHandler(conf *models.Config) *JobHandler {
-	return &JobHandler{
-		conf: conf,
-	}
-}
-
-func (h *JobHandler) Handle(ctx context.Context, request fdk.Request) fdk.Response {
-	response := fdk.Response{}
-	if request.Params.Query == nil {
-		response.Code = http.StatusBadRequest
-		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: "Request does not have query params"})
-		return response
-	}
-
-	queryParams := request.Params.Query[queryIDParam]
+func handleSaveJobVersion(ctx context.Context, r fdk.Request) fdk.Response {
+	const queryIDParam = "id"
+	queryParams := r.Params.Query[queryIDParam]
 	if len(queryParams) != 1 {
-		response.Code = http.StatusBadRequest
-		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: fmt.Sprintf("query params %s length: %d is incorrect", queryIDParam, len(queryIDParam))})
-		return response
+		return fdk.ErrResp(fdk.APIError{Code: http.StatusBadRequest, Message: fmt.Sprintf("query params %s length: %d is incorrect", queryIDParam, len(queryParams))})
 	}
 
-	fc, err := models.FalconClient(ctx, h.conf, request)
-	if err != nil {
-		response.Code = http.StatusInternalServerError
-		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: "fail to initialize client"})
-		return response
-	}
-
-	job, errs := h.job(ctx, queryParams[0], fc)
+	job, errs := saveJob(ctx, queryParams[0], getFalconClient(ctx))
 	if len(errs) != 0 {
+		response := fdk.ErrResp(errs...)
 		if strings.Contains(errs[0].Message, "not found") {
 			response.Code = http.StatusNotFound
 		}
-		response.Errors = append(response.Errors, errs...)
 		return response
 	}
 
-	body, err := json.Marshal(job)
-	if err != nil {
-		response = fdk.Response{
-			Code: http.StatusInternalServerError,
-			Errors: []fdk.APIError{
-				{Code: http.StatusInternalServerError, Message: "failed marshalling response body"},
-			},
-		}
-		return response
-	}
-
-	response.Body = json.RawMessage(body)
-	response.Code = http.StatusOK
-
-	return response
+	return fdk.Response{Code: http.StatusOK, Body: fdk.JSON(job)}
 }
 
-// job saves a job to custom storage and may attempt to run or schedule the job if requested.
-func (h *JobHandler) job(ctx context.Context, id string, fc *client.CrowdStrikeAPISpecification) (*models.JobResponse, []fdk.APIError) {
-	job, errs := jobInfo(ctx, id, h.conf, fc)
+// saveJob saves a job to custom storage and may attempt to run or schedule the job if requested.
+func saveJob(ctx context.Context, id string, fc *client.CrowdStrikeAPISpecification) (*models.JobResponse, []fdk.APIError) {
+	job, errs := jobInfo(ctx, id, fc)
 	if len(errs) != 0 {
 		return nil, errs
 	}
-	result := models.JobResponse{
-		Resource: *job,
-	}
-	return &result, nil
+	return &models.JobResponse{Resource: job}, nil
 }

--- a/functions/Func_Jobs/api/job_upsert.go
+++ b/functions/Func_Jobs/api/job_upsert.go
@@ -1,81 +1,52 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"io"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
 	"github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/crowdstrike/gofalcon/falcon/client/custom_storage"
+	"github.com/crowdstrike/gofalcon/falcon/client/hosts"
+	"github.com/crowdstrike/gofalcon/falcon/client/workflows"
+	model "github.com/crowdstrike/gofalcon/falcon/models"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
-const queryIsDraft = "draft"
+const (
+	JobCreated ActionTaken = "Created"
+	JobEdited  ActionTaken = "Updated"
 
-// UpsertJobHandler executes a given request to the FaaS function.
-type UpsertJobHandler struct {
-	conf *models.Config
-}
+	deviceHostGroups = "groups"
+)
 
-// NewUpsertJobHandler returns a new instance of UpsertJobHandler.
-func NewUpsertJobHandler(conf *models.Config) *UpsertJobHandler {
-	return &UpsertJobHandler{
-		conf: conf,
-	}
-}
+// ActionTaken enumerates the list of action taken on job
+type ActionTaken string
 
-func (h *UpsertJobHandler) Handle(ctx context.Context, request fdk.Request) fdk.Response {
-	response := fdk.Response{}
-	var isDraft bool
+func handleUpsertJob(conf models.Config) fdk.Handler {
+	return fdk.HandleFnOf(func(ctx context.Context, r fdk.RequestOf[models.UpsertJobRequest]) fdk.Response {
+		isDraft := r.Params.Query.Get("draft") == "true"
+		var req models.UpsertJobRequest
 
-	var req models.UpsertJobRequest
-	var errs []fdk.APIError
+		result, errs := upsertJob(ctx, conf, isDraft, &req, getFalconClient(ctx))
+		if len(errs) != 0 {
+			return fdk.ErrResp(errs...)
+		}
 
-	// TODO: replace with fdk.HandlerFnOf
-	err := json.NewDecoder(request.Body).Decode(&req)
-	if err != nil {
-		response.Code = http.StatusBadRequest
-		response.Errors = append(response.Errors, models.NewAPIError(http.StatusBadRequest, fmt.Sprintf("Failed to unmarshal Request body err: %v.", err)))
-		return response
-	}
-
-	queryParams := request.Params.Query.Get(queryIsDraft)
-	if queryParams == "true" {
-		isDraft = true
-	}
-
-	fc, err := models.FalconClient(ctx, h.conf, request)
-	if err != nil {
-		response.Code = http.StatusInternalServerError
-		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: "fail to initialize client"})
-		return response
-	}
-
-	result, errs := h.upsertJob(ctx, isDraft, &req, fc)
-	if len(errs) != 0 {
-		response.Code = http.StatusInternalServerError
-		response.Errors = errs
-		return response
-	}
-
-	body, err := json.Marshal(result)
-	if err != nil {
-		response.Code = http.StatusInternalServerError
-		response.Errors = append(response.Errors, models.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("failed to marshal the response body with err: %v", err)))
-		return response
-	}
-
-	response.Body = json.RawMessage(body)
-	response.Code = http.StatusOK
-	return response
+		return fdk.Response{Code: http.StatusOK, Body: fdk.JSON(result)}
+	})
 }
 
 // upsertJob saves a job to custom storage and may attempt to run or schedule the job if requested.
-func (h *UpsertJobHandler) upsertJob(ctx context.Context, isDraft bool, req *models.UpsertJobRequest, fc *client.CrowdStrikeAPISpecification) (*models.UpsertJobResponse, []fdk.APIError) {
+func upsertJob(ctx context.Context, conf models.Config, isDraft bool, req *models.UpsertJobRequest, fc *client.CrowdStrikeAPISpecification) (*models.UpsertJobResponse, []fdk.APIError) {
 	var errs []fdk.APIError
 	var err error
 
@@ -85,74 +56,52 @@ func (h *UpsertJobHandler) upsertJob(ctx context.Context, isDraft bool, req *mod
 	}
 
 	id := req.ID
-	start := time.Now()
-	startEndTOEnd := time.Now()
-
 	if id == "" {
 		id, err = models.GenerateID(req.Name)
 		if err != nil {
-			validationErr = append(validationErr, models.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("failed to generate id for job: %s with err: %v", req.Name, err)))
-			return nil, validationErr
+			return nil, []fdk.APIError{models.NewAPIError(http.StatusInternalServerError, fmt.Sprintf("failed to generate id for job: %s with err: %v", req.Name, err))}
 		}
-		prevJob, errs := jobInfo(ctx, id, h.conf, fc)
-		if len(errs) != 0 {
-			if errs[0].Code != http.StatusNotFound {
-				validationErr = append(validationErr, errs...)
-				return nil, errs
-			}
-		}
-		if prevJob != nil {
-			validationErr = append(validationErr, fdk.APIError{
+
+		_, errs := jobInfo(ctx, id, fc)
+		if len(errs) == 0 {
+			return nil, append(validationErr, fdk.APIError{
 				Code:    http.StatusBadRequest,
 				Message: fmt.Sprintf("job with name:%s already exist", req.Name),
 			})
-			return nil, validationErr
 		}
-		elapsed := time.Since(start).Seconds()
-		log.Println("time elasped get job id ", elapsed)
+		if errs[0].Code != http.StatusNotFound {
+			return nil, errs
+		}
 	}
 
-	decorateErr := h.decorateRequest(ctx, isDraft, id, &req.Job, fc)
+	decorateErr := decorateRequest(ctx, conf, isDraft, id, &req.Job, fc)
 	if len(decorateErr) != 0 {
-		validationErr = append(validationErr, decorateErr...)
-		return nil, validationErr
+		return nil, append(validationErr, decorateErr...)
 	}
-
-	start = time.Now()
 
 	// create the object in the custom_storage.
-	jobID, errs := putJob(ctx, &req.Job, h.conf, fc)
+	jobID, errs := putJob(ctx, &req.Job, fc)
 	if len(errs) != 0 {
 		validationErr = append(validationErr, errs...)
 		return nil, validationErr
 	}
-
-	elapsed := time.Since(start).Seconds()
-	log.Println("time elasped upsert job id ", elapsed)
-	start = time.Now()
 
 	action := JobEdited
 	if req.Version == 1 {
 		action = JobCreated
 	}
 
-	errs = auditLogProducer(ctx, action, &req.Job, h.conf, fc)
+	errs = auditLogProducer(ctx, action, &req.Job, fc)
 	if len(errs) != 0 {
 		// we do not rollback transaction if auditlogger fails
 		validationErr = append(validationErr, errs...)
 		return nil, validationErr
 	}
 
-	elapsed = time.Since(start).Seconds()
-	log.Println("time elasped audit job id ", elapsed)
-
-	elapsed = time.Since(startEndTOEnd).Seconds()
-	log.Println("total time ", elapsed)
-
 	return &models.UpsertJobResponse{Resource: jobID}, nil
 }
 
-func (h *UpsertJobHandler) decorateRequest(ctx context.Context, isDraft bool, id string, req *models.Job, fc *client.CrowdStrikeAPISpecification) []fdk.APIError {
+func decorateRequest(ctx context.Context, conf models.Config, isDraft bool, id string, req *models.Job, fc *client.CrowdStrikeAPISpecification) []fdk.APIError {
 	if !isDraft {
 		req.WSchedule = updateSchedule(req)
 
@@ -176,12 +125,12 @@ func (h *UpsertJobHandler) decorateRequest(ctx context.Context, isDraft bool, id
 		}
 
 		req.TotalRecurrences = recurrences
-		workflowId, errs := provisionWorkflowWithAct(ctx, req, h.conf, fc)
+		workflowId, errs := provisionWorkflowWithAct(ctx, req, conf, fc)
 		if len(errs) != 0 {
 			return errs
 		}
 
-		executionWorkflowID, errs := provisionWorkflowForExec(ctx, req, h.conf, workflowId, fc)
+		executionWorkflowID, errs := provisionWorkflowForExec(ctx, req, conf, workflowId, fc)
 		if len(errs) != 0 {
 			return errs
 		}
@@ -211,6 +160,295 @@ func (h *UpsertJobHandler) decorateRequest(ctx context.Context, isDraft bool, id
 	}
 
 	return errs
+}
+
+func auditLogProducer(ctx context.Context, event ActionTaken, req *models.Job, fc *client.CrowdStrikeAPISpecification) []fdk.APIError {
+	var errs []fdk.APIError
+	logId := fmt.Sprintf("%d%s", time.Now().UnixNano(), req.ID)
+
+	customJobRequest := custom_storage.NewPutObjectParamsWithContext(ctx)
+	customJobRequest.SetObjectKey(logId)
+	customJobRequest.SetCollectionName(collectionAudit)
+
+	auditLogsBody := models.Audit{
+		JobName:    req.Name,
+		ModifiedAt: req.UpdatedAt,
+		Version:    req.Version,
+		ModifiedBy: req.UserName,
+		Action:     string(event),
+		JobID:      req.ID,
+		ID:         logId,
+	}
+
+	rawObject, err := json.Marshal(auditLogsBody)
+	if err != nil {
+		return []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+	obj := io.NopCloser(bytes.NewReader(rawObject))
+	customJobRequest.SetBody(obj)
+
+	_, err = fc.CustomStorage.PutObject(customJobRequest)
+	if err != nil {
+		return []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+
+	return errs
+}
+
+func provisionWorkflowWithAct(ctx context.Context, req *models.Job, conf models.Config, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
+	var errs []fdk.APIError
+	triggerNodeID := "trigger"
+	reqBody := &model.ClientSystemDefinitionProvisionRequest{}
+	reqBody.Name = &req.Name
+	reqBody.Parameters = &model.ParameterTemplateProvisionParameters{}
+	reqBody.Parameters.Trigger = &model.ParameterTriggerProvisionParameter{}
+	reqBody.Parameters.Activities = &model.ParameterActivityProvisionParameters{}
+	schedule := map[string]interface{}{
+		"time_cycle":      req.WSchedule.TimeCycle,
+		"tz":              req.WSchedule.Timezone,
+		"skip_concurrent": false,
+	}
+	if len(req.WSchedule.Start) > 0 {
+		schedule["start_date"] = req.WSchedule.Start
+	}
+	if len(req.WSchedule.End) > 0 {
+		schedule["end_date"] = req.WSchedule.End
+	}
+	scheduleParams := model.ParameterTriggerFieldParameter{
+		Properties: schedule,
+	}
+	reqBody.Parameters.Trigger.NodeID = &triggerNodeID
+	reqBody.Parameters.Trigger.Fields = make(map[string]model.ParameterTriggerFieldParameter)
+	reqBody.Parameters.Trigger.Fields["timer_event_definition"] = scheduleParams
+
+	conditionForHostAndGroupsName := model.ParameterConditionProvisionParameter{
+		Fields: []*model.ParameterConditionFieldProvisionParameter{},
+	}
+
+	switch req.Action.Type {
+	case models.RemoveFile:
+		removeNodeID := "remove_file_rtr_2_65337911"
+		removeFile := model.ParameterActivityConfigProvisionParameter{
+			NodeID: &removeNodeID,
+			Properties: map[string]interface{}{
+				"filePath": fmt.Sprintf("%s\\%s", req.Action.RemoveFileAction.RemoveFilePath, req.Action.RemoveFileAction.RemoveFileName),
+			},
+		}
+		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &removeFile)
+
+		checkFileExistNodeID := "check_file_exist_rtr_2_e7dcae9e"
+		checkFileExist := model.ParameterActivityConfigProvisionParameter{
+			NodeID: &checkFileExistNodeID,
+			Properties: map[string]interface{}{
+				"filePath": fmt.Sprintf("%s\\%s", req.Action.RemoveFileAction.RemoveFilePath, req.Action.RemoveFileAction.RemoveFileName),
+			},
+		}
+
+		conditionForHostAndGroupsName.NodeID = &conf.RemoveConditionNodeID
+
+		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &checkFileExist)
+		reqBody.TemplateName = &conf.RemoveSystemWorkflowTemplateID
+
+	case models.InstallSoftware:
+		installNodeID := "put_and_run_file_b3305a8e"
+		installSoft := model.ParameterActivityConfigProvisionParameter{
+			NodeID: &installNodeID,
+			Properties: map[string]interface{}{
+				"file_name": req.Action.InstallSoftwareAction.FileName,
+				"params":    req.Action.InstallSoftwareAction.CommandSwitch,
+			},
+		}
+
+		conditionForHostAndGroupsName.NodeID = &conf.InstallConditionNodeID
+
+		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &installSoft)
+		reqBody.TemplateName = &conf.InstallSystemWorkflowTemplateID
+
+	default:
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: fmt.Sprintf("Handle type is incorrect %s", req.Action.Type.String()),
+		}}
+	}
+
+	op := "IN"
+	opNotIN := "NOT_IN"
+	hostNameField := "device_query_d360b503.Device.query.devices.#"
+	groupNameField := "get_device_details_e84112c6.Device.GetDetails.Groups"
+
+	hostNameCondition := &model.ParameterConditionFieldProvisionParameter{
+		Name:  &hostNameField,
+		Value: req.Target.Hosts,
+	}
+	groupNameCondition := &model.ParameterConditionFieldProvisionParameter{
+		Name:  &groupNameField,
+		Value: req.Target.HostGroups,
+	}
+
+	if len(req.Target.Hosts) != 0 {
+		hostNameCondition.Operator = &op
+		groupNameCondition.Operator = &opNotIN
+		groupNameCondition.Value = []string{"undefined"}
+	} else {
+		hostNameCondition.Operator = &opNotIN
+		groupNameCondition.Operator = &op
+		hostNameCondition.Value = []string{"undefined"}
+	}
+
+	conditionForHostAndGroupsName.Fields = append(conditionForHostAndGroupsName.Fields, hostNameCondition, groupNameCondition)
+	reqBody.Parameters.Conditions = append(reqBody.Parameters.Conditions, &conditionForHostAndGroupsName)
+
+	provisionReq := workflows.NewProvisionSystemDefinitionParams()
+	provisionReq.SetBody(reqBody)
+	provisionReq.SetContext(ctx)
+	resp, err := fc.Workflows.ProvisionSystemDefinition(provisionReq)
+	if err != nil {
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+	if len(resp.GetPayload().Errors) != 0 {
+		errs = convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
+		return "", errs
+	}
+	if len(resp.GetPayload().Resources) == 0 {
+		return "", []fdk.APIError{
+			{
+				Code:    2001,
+				Message: fmt.Sprintf("resources from workflow is 0 response:%v", resp),
+			},
+		}
+	}
+	workflowID := resp.GetPayload().Resources[0]
+	return workflowID, errs
+}
+
+func provisionWorkflowForExec(ctx context.Context, req *models.Job, conf models.Config, workflowID string, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
+	var errs []fdk.APIError
+	conditionNodeID := "flow_FROM_workflow_execution_id_is_equal_to_parameterized_6eb5201d_TO_activity_update_job_history_63aa1ffe"
+	op := "EQ"
+	propName := "Trigger.Category.WorkflowExecution.DefinitionID"
+
+	reqBody := &model.ClientSystemDefinitionProvisionRequest{}
+	reqBody.Name = &req.Name
+	reqBody.TemplateName = &conf.ExecutionNotifierWorkflow
+	reqBody.Parameters = &model.ParameterTemplateProvisionParameters{}
+
+	reqBody.Parameters.Conditions = []*model.ParameterConditionProvisionParameter{
+		{
+			NodeID: &conditionNodeID,
+			Fields: []*model.ParameterConditionFieldProvisionParameter{
+				{
+					Name:     &propName,
+					Operator: &op,
+					Value:    workflowID,
+				},
+			},
+		},
+	}
+
+	emailNodeID := "activity_send_email_c6dbab17"
+	emailNotification := model.ParameterActivityConfigProvisionParameter{
+		NodeID: &emailNodeID,
+		Properties: map[string]interface{}{
+			"to": req.Notifications,
+		},
+	}
+	reqBody.Parameters.Activities = &model.ParameterActivityProvisionParameters{}
+	reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &emailNotification)
+
+	provisionReq := workflows.NewProvisionSystemDefinitionParams()
+	provisionReq.SetBody(reqBody)
+	provisionReq.Context = ctx
+
+	resp, err := fc.Workflows.ProvisionSystemDefinition(provisionReq)
+	if err != nil {
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+
+	if len(resp.GetPayload().Errors) != 0 {
+		errs = convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
+		return "", errs
+	}
+
+	return resp.GetPayload().Resources[0], errs
+}
+
+func putJob(ctx context.Context, req *models.Job, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
+	var errs []fdk.APIError
+	rawObject, err := json.Marshal(req)
+	if err != nil {
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+
+	customJobRequest := custom_storage.NewPutObjectParamsWithContext(ctx)
+	customJobRequest.SetObjectKey(req.ID)
+	customJobRequest.SetCollectionName(collectionJobs)
+
+	obj := io.NopCloser(bytes.NewReader(rawObject))
+	customJobRequest.SetBody(obj)
+
+	response, err := fc.CustomStorage.PutObject(customJobRequest)
+	if err != nil {
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+
+	if len(response.GetPayload().Errors) > 0 {
+		errs = convertMsaErrorsToAPIErrors(response.GetPayload().Errors)
+		return "", errs
+	}
+
+	if response.GetPayload().Resources[0].ObjectKey == nil {
+		return "", []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: "failed to upsert the job. key is empty in the response",
+		}}
+	}
+
+	return *response.GetPayload().Resources[0].ObjectKey, errs
+}
+
+func getDeviceCountForHostGroup(ctx context.Context, hostgroups []string, fc *client.CrowdStrikeAPISpecification) (int, []fdk.APIError) {
+	var fqlStrings []string
+	for _, grp := range hostgroups {
+		fqlStrings = append(fqlStrings, fmt.Sprintf("%s:'%s'", deviceHostGroups, grp))
+	}
+
+	fqlAnd := ","
+	fql := strings.Join(fqlStrings, fqlAnd)
+
+	reqBody := hosts.NewQueryDevicesByFilterParamsWithContext(ctx)
+	reqBody.SetFilter(&fql)
+	resp, err := fc.Hosts.QueryDevicesByFilter(reqBody)
+	if err != nil {
+		return 0, []fdk.APIError{{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		}}
+	}
+
+	if len(resp.GetPayload().Errors) != 0 {
+		errs := convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
+		return 0, errs
+	}
+
+	return len(resp.GetPayload().Resources), nil
 }
 
 // isNextRunValid check to see if next run is valid.  It has to be previousRun< Nextrun also start_time<nextrun<endtime, if so insert the next run

--- a/functions/Func_Jobs/api/models/config.go
+++ b/functions/Func_Jobs/api/models/config.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"strings"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/crowdstrike/gofalcon/falcon"
 	"github.com/crowdstrike/gofalcon/falcon/client"
 )
 
 type Config struct {
 	Cloud                           falcon.CloudType
-	JobsCollection                  string
-	AuditLogsCollection             string
 	RemoveSystemWorkflowTemplateID  string
 	RemoveConditionNodeID           string
 	InstallSystemWorkflowTemplateID string
@@ -24,19 +21,19 @@ type Config struct {
 // FalconClient returns a new instance of the GoFalcon client.
 // If the client cannot be created or if there is no access token in the request,
 // an error is returned.
-func FalconClient(ctx context.Context, conf *Config, r fdk.Request) (*client.CrowdStrikeAPISpecification, error) {
-	token := strings.TrimSpace(r.AccessToken)
+func FalconClient(ctx context.Context, cloud falcon.CloudType, accessToken string) (*client.CrowdStrikeAPISpecification, error) {
+	token := strings.TrimSpace(accessToken)
 	if token == "" {
 		return falcon.NewClient(&falcon.ApiConfig{
 			AccessToken: token,
-			Cloud:       conf.Cloud,
+			Cloud:       cloud,
 			Context:     context.Background(),
 			Debug:       true,
 		})
 	}
 	return falcon.NewClient(&falcon.ApiConfig{
 		AccessToken: token,
-		Cloud:       conf.Cloud,
+		Cloud:       cloud,
 		Context:     ctx,
 	})
 }

--- a/functions/Func_Jobs/api/models/job.go
+++ b/functions/Func_Jobs/api/models/job.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/robfig/cron/v3"
 	"github.com/spaolacci/murmur3"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
 const (

--- a/functions/Func_Jobs/api/utils.go
+++ b/functions/Func_Jobs/api/utils.go
@@ -7,142 +7,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
 	"github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/custom_storage"
-	"github.com/crowdstrike/gofalcon/falcon/client/hosts"
-	"github.com/crowdstrike/gofalcon/falcon/client/workflows"
 	model "github.com/crowdstrike/gofalcon/falcon/models"
-	"github.com/go-openapi/runtime"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
 const (
-	JobCreated ActionTaken = "Created"
-	JobEdited  ActionTaken = "Updated"
-
-	deviceHostGroups = "groups"
+	collectionAudit = "Jobs_Audit_logger"
+	collectionJobs  = "Jobs_Info"
 )
 
-// ActionTaken enumerates the list of action taken on job
-type ActionTaken string
-
-func auditLogProducer(ctx context.Context, event ActionTaken, req *models.Job, conf *models.Config, fc *client.CrowdStrikeAPISpecification) []fdk.APIError {
-	var errs []fdk.APIError
-	logId := fmt.Sprintf("%d%s", time.Now().UnixNano(), req.ID)
-
-	customJobRequest := custom_storage.NewPutObjectParamsWithContext(ctx)
-	customJobRequest.SetObjectKey(logId)
-	customJobRequest.SetCollectionName(conf.AuditLogsCollection)
-
-	auditLogsBody := models.Audit{
-		JobName:    req.Name,
-		ModifiedAt: req.UpdatedAt,
-		Version:    req.Version,
-		ModifiedBy: req.UserName,
-		Action:     string(event),
-		JobID:      req.ID,
-		ID:         logId,
-	}
-
-	rawObject, err := json.Marshal(auditLogsBody)
-	if err != nil {
-		return []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-	obj := io.NopCloser(bytes.NewReader(rawObject))
-	customJobRequest.SetBody(obj)
-
-	_, err = fc.CustomStorage.PutObject(customJobRequest)
-	if err != nil {
-		return []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	return errs
-}
-
-func putJob(ctx context.Context, req *models.Job, conf *models.Config, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
-	var errs []fdk.APIError
-	rawObject, err := json.Marshal(req)
-	if err != nil {
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	customJobRequest := custom_storage.NewPutObjectParamsWithContext(ctx)
-	customJobRequest.SetObjectKey(req.ID)
-	customJobRequest.SetCollectionName(conf.JobsCollection)
-
-	obj := io.NopCloser(bytes.NewReader(rawObject))
-	customJobRequest.SetBody(obj)
-
-	response, err := fc.CustomStorage.PutObject(customJobRequest)
-	if err != nil {
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	if len(response.GetPayload().Errors) > 0 {
-		errs = convertMsaErrorsToAPIErrors(response.GetPayload().Errors)
-		return "", errs
-	}
-
-	if response.GetPayload().Resources[0].ObjectKey == nil {
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: "failed to upsert the job. key is empty in the response",
-		}}
-	}
-
-	return *response.GetPayload().Resources[0].ObjectKey, errs
-}
-
-func jobInfo(ctx context.Context, id string, conf *models.Config, fc *client.CrowdStrikeAPISpecification) (*models.Job, []fdk.APIError) {
-	var errs []fdk.APIError
-
-	customJobRequest := custom_storage.NewGetObjectParamsWithContext(ctx)
-	customJobRequest.SetObjectKey(id)
-	customJobRequest.SetCollectionName(conf.JobsCollection)
-
-	buf := new(bytes.Buffer)
-	_, err := fc.CustomStorage.GetObject(customJobRequest, buf)
-	if err != nil {
-		runtimeErr := err.(*runtime.APIError)
-		return nil, []fdk.APIError{{
-			Code:    runtimeErr.Code,
-			Message: err.Error(),
-		}}
-	}
-	rawResponse, err := io.ReadAll(buf)
-	if err != nil {
-		return nil, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	var result models.Job
-	err = json.Unmarshal(rawResponse, &result)
-	if err != nil {
-		return nil, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	return &result, errs
+func jobInfo(ctx context.Context, id string, fc *client.CrowdStrikeAPISpecification) (models.Job, []fdk.APIError) {
+	return getObject[models.Job](ctx, id, collectionJobs, fc)
 }
 
 func search(ctx context.Context, req models.SearchObjectsRequest, fc *client.CrowdStrikeAPISpecification) (models.SearchObjectsResponse, []fdk.APIError) {
@@ -182,8 +63,8 @@ func search(ctx context.Context, req models.SearchObjectsRequest, fc *client.Cro
 
 	sor := models.SearchObjectsResponse{}
 	if pagination := payload.Meta.Pagination; pagination != nil {
-		sor.Total = int64PAsInt(pagination.Total)
-		sor.Offset = int32PAsInt(pagination.Offset)
+		sor.Total = int(from(pagination.Total))
+		sor.Offset = int(from(pagination.Offset))
 	}
 	res := payload.Resources
 	if len(res) == 0 {
@@ -191,255 +72,9 @@ func search(ctx context.Context, req models.SearchObjectsRequest, fc *client.Cro
 	}
 	sor.ObjectKeys = make([]string, len(res))
 	for i, r := range res {
-		sor.ObjectKeys[i] = asString(r.ObjectKey)
+		sor.ObjectKeys[i] = from(r.ObjectKey)
 	}
 	return sor, nil
-}
-
-func auditInfo(ctx context.Context, id string, conf *models.Config, fc *client.CrowdStrikeAPISpecification) (*models.Audit, []fdk.APIError) {
-	var errs []fdk.APIError
-
-	customJobRequest := custom_storage.NewGetObjectParamsWithContext(ctx)
-	customJobRequest.SetObjectKey(id)
-	customJobRequest.SetCollectionName(conf.AuditLogsCollection)
-
-	buf := new(bytes.Buffer)
-	_, err := fc.CustomStorage.GetObject(customJobRequest, buf)
-	if err != nil {
-		return nil, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	rawResponse, err := io.ReadAll(buf)
-	if err != nil {
-		return nil, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	var result models.Audit
-	err = json.Unmarshal(rawResponse, &result)
-	if err != nil {
-		return nil, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	return &result, errs
-}
-
-func provisionWorkflowForExec(ctx context.Context, req *models.Job, conf *models.Config, workflowID string, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
-	var errs []fdk.APIError
-	conditionNodeID := "flow_FROM_workflow_execution_id_is_equal_to_parameterized_6eb5201d_TO_activity_update_job_history_63aa1ffe"
-	op := "EQ"
-	propName := "Trigger.Category.WorkflowExecution.DefinitionID"
-
-	reqBody := &model.ClientSystemDefinitionProvisionRequest{}
-	reqBody.Name = &req.Name
-	reqBody.TemplateName = &conf.ExecutionNotifierWorkflow
-	reqBody.Parameters = &model.ParameterTemplateProvisionParameters{}
-
-	reqBody.Parameters.Conditions = []*model.ParameterConditionProvisionParameter{
-		{
-			NodeID: &conditionNodeID,
-			Fields: []*model.ParameterConditionFieldProvisionParameter{
-				{
-					Name:     &propName,
-					Operator: &op,
-					Value:    workflowID,
-				},
-			},
-		},
-	}
-
-	emailNodeID := "activity_send_email_c6dbab17"
-	emailNotification := model.ParameterActivityConfigProvisionParameter{
-		NodeID: &emailNodeID,
-		Properties: map[string]interface{}{
-			"to": req.Notifications,
-		},
-	}
-	reqBody.Parameters.Activities = &model.ParameterActivityProvisionParameters{}
-	reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &emailNotification)
-
-	provisionReq := workflows.NewProvisionSystemDefinitionParams()
-	provisionReq.SetBody(reqBody)
-	provisionReq.Context = ctx
-
-	resp, err := fc.Workflows.ProvisionSystemDefinition(provisionReq)
-	if err != nil {
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	if len(resp.GetPayload().Errors) != 0 {
-		errs = convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
-		return "", errs
-	}
-
-	return resp.GetPayload().Resources[0], errs
-}
-
-func provisionWorkflowWithAct(ctx context.Context, req *models.Job, conf *models.Config, fc *client.CrowdStrikeAPISpecification) (string, []fdk.APIError) {
-	var errs []fdk.APIError
-	triggerNodeID := "trigger"
-	reqBody := &model.ClientSystemDefinitionProvisionRequest{}
-	reqBody.Name = &req.Name
-	reqBody.Parameters = &model.ParameterTemplateProvisionParameters{}
-	reqBody.Parameters.Trigger = &model.ParameterTriggerProvisionParameter{}
-	reqBody.Parameters.Activities = &model.ParameterActivityProvisionParameters{}
-	schedule := map[string]interface{}{
-		"time_cycle":      req.WSchedule.TimeCycle,
-		"tz":              req.WSchedule.Timezone,
-		"skip_concurrent": false,
-	}
-	if len(req.WSchedule.Start) > 0 {
-		schedule["start_date"] = req.WSchedule.Start
-	}
-	if len(req.WSchedule.End) > 0 {
-		schedule["end_date"] = req.WSchedule.End
-	}
-	scheduleParams := model.ParameterTriggerFieldParameter{
-		Properties: schedule,
-	}
-	reqBody.Parameters.Trigger.NodeID = &triggerNodeID
-	reqBody.Parameters.Trigger.Fields = make(map[string]model.ParameterTriggerFieldParameter)
-	reqBody.Parameters.Trigger.Fields["timer_event_definition"] = scheduleParams
-
-	conditionForHostAndGroupsName := model.ParameterConditionProvisionParameter{
-		Fields: []*model.ParameterConditionFieldProvisionParameter{},
-	}
-
-	switch req.Action.Type {
-	case models.RemoveFile:
-		removeNodeID := "remove_file_rtr_2_65337911"
-		removeFile := model.ParameterActivityConfigProvisionParameter{
-			NodeID: &removeNodeID,
-			Properties: map[string]interface{}{
-				"filePath": fmt.Sprintf("%s\\%s", req.Action.RemoveFileAction.RemoveFilePath, req.Action.RemoveFileAction.RemoveFileName),
-			},
-		}
-		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &removeFile)
-
-		checkFileExistNodeID := "check_file_exist_rtr_2_e7dcae9e"
-		checkFileExist := model.ParameterActivityConfigProvisionParameter{
-			NodeID: &checkFileExistNodeID,
-			Properties: map[string]interface{}{
-				"filePath": fmt.Sprintf("%s\\%s", req.Action.RemoveFileAction.RemoveFilePath, req.Action.RemoveFileAction.RemoveFileName),
-			},
-		}
-
-		conditionForHostAndGroupsName.NodeID = &conf.RemoveConditionNodeID
-
-		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &checkFileExist)
-		reqBody.TemplateName = &conf.RemoveSystemWorkflowTemplateID
-
-	case models.InstallSoftware:
-		installNodeID := "put_and_run_file_b3305a8e"
-		installSoft := model.ParameterActivityConfigProvisionParameter{
-			NodeID: &installNodeID,
-			Properties: map[string]interface{}{
-				"file_name": req.Action.InstallSoftwareAction.FileName,
-				"params":    req.Action.InstallSoftwareAction.CommandSwitch,
-			},
-		}
-
-		conditionForHostAndGroupsName.NodeID = &conf.InstallConditionNodeID
-
-		reqBody.Parameters.Activities.Configuration = append(reqBody.Parameters.Activities.Configuration, &installSoft)
-		reqBody.TemplateName = &conf.InstallSystemWorkflowTemplateID
-
-	default:
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: fmt.Sprintf("Handle type is incorrect %s", req.Action.Type.String()),
-		}}
-	}
-
-	op := "IN"
-	opNotIN := "NOT_IN"
-	hostNameField := "device_query_d360b503.Device.query.devices.#"
-	groupNameField := "get_device_details_e84112c6.Device.GetDetails.Groups"
-
-	hostNameCondition := &model.ParameterConditionFieldProvisionParameter{
-		Name:  &hostNameField,
-		Value: req.Target.Hosts,
-	}
-	groupNameCondition := &model.ParameterConditionFieldProvisionParameter{
-		Name:  &groupNameField,
-		Value: req.Target.HostGroups,
-	}
-
-	if len(req.Target.Hosts) != 0 {
-		hostNameCondition.Operator = &op
-		groupNameCondition.Operator = &opNotIN
-		groupNameCondition.Value = []string{"undefined"}
-	} else {
-		hostNameCondition.Operator = &opNotIN
-		groupNameCondition.Operator = &op
-		hostNameCondition.Value = []string{"undefined"}
-	}
-
-	conditionForHostAndGroupsName.Fields = append(conditionForHostAndGroupsName.Fields, hostNameCondition, groupNameCondition)
-	reqBody.Parameters.Conditions = append(reqBody.Parameters.Conditions, &conditionForHostAndGroupsName)
-
-	provisionReq := workflows.NewProvisionSystemDefinitionParams()
-	provisionReq.SetBody(reqBody)
-	provisionReq.SetContext(ctx)
-	resp, err := fc.Workflows.ProvisionSystemDefinition(provisionReq)
-	if err != nil {
-		return "", []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-	if len(resp.GetPayload().Errors) != 0 {
-		errs = convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
-		return "", errs
-	}
-	if len(resp.GetPayload().Resources) == 0 {
-		return "", []fdk.APIError{
-			{
-				Code:    2001,
-				Message: fmt.Sprintf("resources from workflow is 0 response:%v", resp),
-			},
-		}
-	}
-	workflowID := resp.GetPayload().Resources[0]
-	return workflowID, errs
-}
-
-func getDeviceCountForHostGroup(ctx context.Context, hostgroups []string, fc *client.CrowdStrikeAPISpecification) (int, []fdk.APIError) {
-	var fqlStrings []string
-	for _, grp := range hostgroups {
-		fqlStrings = append(fqlStrings, fmt.Sprintf("%s:'%s'", deviceHostGroups, grp))
-	}
-
-	fqlAnd := ","
-	fql := strings.Join(fqlStrings, fqlAnd)
-
-	reqBody := hosts.NewQueryDevicesByFilterParamsWithContext(ctx)
-	reqBody.SetFilter(&fql)
-	resp, err := fc.Hosts.QueryDevicesByFilter(reqBody)
-	if err != nil {
-		return 0, []fdk.APIError{{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
-		}}
-	}
-
-	if len(resp.GetPayload().Errors) != 0 {
-		errs := convertMsaErrorsToAPIErrors(resp.GetPayload().Errors)
-		return 0, errs
-	}
-
-	return len(resp.GetPayload().Resources), nil
 }
 
 func convertMsaErrorsToAPIErrors(msaAPIErrors []*model.MsaAPIError) []fdk.APIError {
@@ -506,23 +141,34 @@ func updateSchedule(req *models.Job) *models.Schedule {
 	return &schedule
 }
 
-func asString(s *string) string {
-	if s == nil {
-		return ""
+func getObject[T any](ctx context.Context, id, collection string, fc *client.CrowdStrikeAPISpecification) (T, []fdk.APIError) {
+	customJobRequest := custom_storage.NewGetObjectParamsWithContext(ctx)
+	customJobRequest.SetObjectKey(id)
+	customJobRequest.SetCollectionName(collection)
+
+	buf := new(bytes.Buffer)
+	_, err := fc.CustomStorage.GetObject(customJobRequest, buf)
+	if err != nil {
+		return *new(T), []fdk.APIError{{Code: http.StatusInternalServerError, Message: err.Error()}}
 	}
-	return *s
+
+	rawResponse, err := io.ReadAll(buf)
+	if err != nil {
+		return *new(T), []fdk.APIError{{Code: http.StatusInternalServerError, Message: err.Error()}}
+	}
+
+	var result T
+	err = json.Unmarshal(rawResponse, &result)
+	if err != nil {
+		return *new(T), []fdk.APIError{{Code: http.StatusInternalServerError, Message: err.Error()}}
+	}
+
+	return result, nil
 }
 
-func int64PAsInt(i *int64) int {
-	if i == nil {
-		return 0
+func from[T any](v *T) T {
+	if v == nil {
+		return *new(T)
 	}
-	return int(*i)
-}
-
-func int32PAsInt(i *int32) int {
-	if i == nil {
-		return 0
-	}
-	return int(*i)
+	return *v
 }

--- a/functions/Func_Jobs/go.mod
+++ b/functions/Func_Jobs/go.mod
@@ -5,9 +5,7 @@ go 1.21
 require (
 	github.com/CrowdStrike/foundry-fn-go v0.21.0
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
-	github.com/go-openapi/runtime v0.26.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spaolacci/murmur3 v1.1.0
 )
 
@@ -21,6 +19,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/loads v0.21.2 // indirect
+	github.com/go-openapi/runtime v0.26.0 // indirect
 	github.com/go-openapi/spec v0.20.9 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
@@ -31,6 +30,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/functions/Func_Jobs/main.go
+++ b/functions/Func_Jobs/main.go
@@ -2,64 +2,23 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
-	api2 "github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api"
+	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
 	"github.com/crowdstrike/gofalcon/falcon"
-	"github.com/sirupsen/logrus"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
-const (
-	upsertJob       = "/upsert-job"
-	getJob          = "/job"
-	getListOfJob    = "/jobs"
-	getListOfAudits = "/audits"
-)
-
-var (
-	logger      logrus.FieldLogger
-	falconCloud falcon.CloudType
-)
-
-func doInit(cloud string) {
-	l := logrus.New()
-	l.SetFormatter(&logrus.JSONFormatter{})
-	logger = l
-
-	falconCloud = falcon.Cloud(cloud)
-}
-
-func handler(context.Context, *slog.Logger, fdk.SkipCfg) fdk.Handler {
-	conf := models.Config{
-		Cloud:                           falconCloud,
-		JobsCollection:                  "Jobs_Info",
-		AuditLogsCollection:             "Jobs_Audit_logger",
+func main() {
+	cfg := models.Config{
+		Cloud:                           falcon.Cloud(os.Getenv("CS_CLOUD")),
 		RemoveSystemWorkflowTemplateID:  "Remove file template",
 		ExecutionNotifierWorkflow:       "Notify job execution template",
 		InstallSystemWorkflowTemplateID: "Install software template",
 		RemoveConditionNodeID:           "platform_is_equal_to_windows_hostname_includes_to_parameterized_host_groups_includes_to_parameterize_831608b0",
 		InstallConditionNodeID:          "FROM_platform_is_equal_to_windows_hostname_includes_to_parameterized_host_groups_includes_to_parameterize_831608b0_TO_activity_check_file_exist_rtr_2_e7dcae9e",
 	}
-
-	upsertJobHandler := api2.NewUpsertJobHandler(&conf)
-	jobHandler := api2.NewJobHandler(&conf)
-	jobsHandler := api2.NewJobsHandler(&conf)
-	auditsHandler := api2.NewAuditsHandler(&conf)
-
-	mux := fdk.NewMux()
-	mux.Get(getJob, jobHandler)
-	mux.Get(getListOfAudits, auditsHandler)
-	mux.Get(getListOfJob, jobsHandler)
-	mux.Put(upsertJob, upsertJobHandler)
-	return mux
-}
-
-func main() {
-	cloud := os.Getenv("CS_CLOUD")
-	doInit(cloud)
-	logger.Print("running")
-	fdk.Run(context.Background(), handler)
+	fdk.Run(context.Background(), api.NewHandler(cfg))
 }

--- a/functions/Func_Jobs/main.go
+++ b/functions/Func_Jobs/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs/api/models"
@@ -13,7 +12,7 @@ import (
 
 func main() {
 	cfg := models.Config{
-		Cloud:                           falcon.Cloud(os.Getenv("CS_CLOUD")),
+		Cloud:                           falcon.Cloud(fdk.FalconClientOpts().Cloud),
 		RemoveSystemWorkflowTemplateID:  "Remove file template",
 		ExecutionNotifierWorkflow:       "Notify job execution template",
 		InstallSystemWorkflowTemplateID: "Install software template",

--- a/functions/job_history/go.mod
+++ b/functions/job_history/go.mod
@@ -7,39 +7,37 @@ require (
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/eapache/go-resiliency v1.4.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spaolacci/murmur3 v1.1.0
 )
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-openapi/analysis v0.21.4 // indirect
-	github.com/go-openapi/errors v0.20.4 // indirect
-	github.com/go-openapi/jsonpointer v0.20.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/loads v0.21.2 // indirect
-	github.com/go-openapi/runtime v0.26.0 // indirect
-	github.com/go-openapi/spec v0.20.9 // indirect
-	github.com/go-openapi/strfmt v0.21.7 // indirect
-	github.com/go-openapi/swag v0.22.4 // indirect
-	github.com/go-openapi/validate v0.22.1 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/go-openapi/analysis v0.22.2 // indirect
+	github.com/go-openapi/errors v0.22.0 // indirect
+	github.com/go-openapi/jsonpointer v0.20.2 // indirect
+	github.com/go-openapi/jsonreference v0.20.4 // indirect
+	github.com/go-openapi/loads v0.21.5 // indirect
+	github.com/go-openapi/runtime v0.27.1 // indirect
+	github.com/go-openapi/spec v0.20.14 // indirect
+	github.com/go-openapi/strfmt v0.22.2 // indirect
+	github.com/go-openapi/swag v0.22.9 // indirect
+	github.com/go-openapi/validate v0.23.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	go.mongodb.org/mongo-driver v1.12.1 // indirect
-	go.opentelemetry.io/otel v1.19.0 // indirect
-	go.opentelemetry.io/otel/metric v1.19.0 // indirect
-	go.opentelemetry.io/otel/trace v1.19.0 // indirect
-	golang.org/x/oauth2 v0.13.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+	go.mongodb.org/mongo-driver v1.14.0 // indirect
+	go.opentelemetry.io/otel v1.21.0 // indirect
+	go.opentelemetry.io/otel/metric v1.21.0 // indirect
+	go.opentelemetry.io/otel/trace v1.21.0 // indirect
+	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect; indirect v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/functions/job_history/main.go
+++ b/functions/job_history/main.go
@@ -9,31 +9,19 @@ import (
 	"os"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/processor"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/searchc"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/storagec"
 	"github.com/crowdstrike/gofalcon/falcon"
 	"github.com/crowdstrike/gofalcon/falcon/client"
-	"github.com/sirupsen/logrus"
-)
 
-var (
-	debug       bool
-	falconHost  string
-	logger      logrus.FieldLogger
-	falconCloud falcon.CloudType
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
 func main() {
-	cloud := os.Getenv("CS_CLOUD")
-	useDebug := os.Getenv("DEBUG")
-	doInit(cloud, useDebug)
-	logger.Print("running")
-	fdk.Run(context.Background(), handler)
-}
+	cloud := fdk.FalconClientOpts().Cloud
 
-func doInit(cloud, useDebug string) {
+	var falconHost string
 	switch cloud {
 	case "us-1":
 		falconHost = "falcon.crowdstrike.com"
@@ -43,156 +31,133 @@ func doInit(cloud, useDebug string) {
 		falconHost = "falcon.eu-1.crowdstrike.com"
 	}
 
-	if useDebug != "" {
-		debug = true
-	}
+	falconCloud := falcon.Cloud(cloud)
 
-	if useDebug != "" {
-		debug = true
-	}
+	fdk.Run(context.Background(), func(_ context.Context, logger *slog.Logger, _ fdk.SkipCfg) fdk.Handler {
+		recoverer := withRecoverer(logger)
 
-	l := logrus.New()
-	l.SetFormatter(&logrus.JSONFormatter{})
-	logger = l
-
-	falconCloud = falcon.Cloud(cloud)
+		mux := fdk.NewMux()
+		mux.Get("/run-history", recoverer(runHistoryHandler(logger, falconCloud)))
+		mux.Put("/upsert", recoverer(upsertHandler(logger, falconCloud, falconHost)))
+		return mux
+	})
 }
 
-func handler(context.Context, *slog.Logger, fdk.SkipCfg) fdk.Handler {
-	mux := fdk.NewMux()
-	mux.Get("/run-history", fdk.HandlerFn(runHistoryHandler))
-	mux.Put("/upsert", fdk.HandlerFn(upsertHandler))
-	return mux
-}
-
-func runHistoryHandler(ctx context.Context, req fdk.Request) (fResp fdk.Response) {
-	defer func() {
-		if fr := ensurePanicLogged(); fr != nil {
-			fResp = *fr
+func runHistoryHandler(logger *slog.Logger, falconCloud falcon.CloudType) fdk.Handler {
+	return fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		p, err := newExecutionsProcessor(ctx, logger, falconCloud, r.AccessToken)
+		if err != nil {
+			msg := fmt.Sprintf("failed to initialize job history processor: %s", err)
+			return fdk.Response{
+				Errors: []fdk.APIError{{Code: 500, Message: msg}},
+			}
 		}
-	}()
-
-	p, err := newExecutionsProcessor(ctx, req.AccessToken)
-	if err != nil {
-		msg := fmt.Sprintf("failed to initialize job history processor: %s", err)
-		logger.Error(msg)
+		resp := p.Process(ctx, r)
+		if len(resp.Errs) > 0 {
+			return fdk.Response{
+				Code:   resp.Code,
+				Errors: resp.Errs,
+			}
+		}
 		return fdk.Response{
-			Errors: []fdk.APIError{{Code: 500, Message: msg}},
-		}
-	}
-	resp := p.Process(ctx, req)
-	if len(resp.Errs) > 0 {
-		fResp = fdk.Response{
-			Code:   resp.Code,
-			Errors: resp.Errs,
-		}
-	} else {
-		fResp = fdk.Response{
 			Body: json.RawMessage(resp.Body),
 			Code: resp.Code,
 		}
-	}
-	return
+	})
 }
 
-func upsertHandler(ctx context.Context, req fdk.Request) (fResp fdk.Response) {
-	defer func() {
-		if fr := ensurePanicLogged(); fr != nil {
-			fResp = *fr
+func upsertHandler(logger *slog.Logger, falconCloud falcon.CloudType, falconHost string) fdk.Handler {
+	return fdk.HandlerFn(func(ctx context.Context, r fdk.Request) fdk.Response {
+		u, err := newUpsertProcessor(ctx, logger, falconCloud, falconHost, r.AccessToken)
+		if err != nil {
+			msg := fmt.Sprintf("failed to initialize job upsert processor: %s", err)
+			return fdk.Response{
+				Errors: []fdk.APIError{{Code: 500, Message: msg}},
+			}
 		}
-	}()
 
-	u, err := newUpsertProcessor(ctx, req.AccessToken)
-	if err != nil {
-		msg := fmt.Sprintf("failed to initialize job upsert processor: %s", err)
-		logger.Error(msg)
+		resp := u.Process(ctx, r)
+		if len(resp.Errs) > 0 {
+			return fdk.Response{
+				Code:   resp.Code,
+				Errors: resp.Errs,
+			}
+		}
+
 		return fdk.Response{
-			Errors: []fdk.APIError{{Code: 500, Message: msg}},
-		}
-	}
-
-	resp := u.Process(ctx, req)
-	if len(resp.Errs) > 0 {
-		fResp = fdk.Response{
-			Code:   resp.Code,
-			Errors: resp.Errs,
-		}
-	} else {
-		fResp = fdk.Response{
 			Body: json.RawMessage(resp.Body),
 			Code: resp.Code,
 		}
-	}
-	return
+	})
 }
 
-func ensurePanicLogged() *fdk.Response {
-	p := recover()
-	if p == nil {
-		return nil
-	}
+func withRecoverer(logger *slog.Logger) func(fdk.Handler) fdk.Handler {
+	return func(next fdk.Handler) fdk.Handler {
+		return fdk.HandlerFn(func(ctx context.Context, r fdk.Request) (resp fdk.Response) {
+			defer func() {
+				p := recover()
+				if p == nil {
+					return
+				}
 
-	msg := ""
-	if s, ok := p.(fmt.Stringer); ok {
-		msg = fmt.Sprintf("fatal error: %s", s)
-	} else if e, ok := p.(error); ok {
-		msg = fmt.Sprintf("fatal error: %s", e.Error())
-	} else {
-		msg = fmt.Sprintf("fatal error: %v", p)
-	}
-	logger.Error(msg)
-	return &fdk.Response{
-		Code: 500,
-		Errors: []fdk.APIError{
-			{Code: 500, Message: msg},
-		},
+				msg := ""
+				if s, ok := p.(fmt.Stringer); ok {
+					msg = fmt.Sprintf("fatal error: %s", s)
+				} else if e, ok := p.(error); ok {
+					msg = fmt.Sprintf("fatal error: %s", e.Error())
+				} else {
+					msg = fmt.Sprintf("fatal error: %v", p)
+				}
+				logger.Error(msg)
+
+				resp = fdk.ErrResp(fdk.APIError{Code: http.StatusInternalServerError, Message: msg})
+			}()
+
+			return next.Handle(ctx, r)
+		})
 	}
 }
 
-func newFalconClient(ctx context.Context, token string) (*client.CrowdStrikeAPISpecification, error) {
+func newFalconClient(ctx context.Context, falconCloud falcon.CloudType, token string) (*client.CrowdStrikeAPISpecification, error) {
 	config := &falcon.ApiConfig{
 		AccessToken: token,
 		Cloud:       falconCloud,
 		Context:     ctx,
-	}
-	if debug {
-		config.Debug = debug
+		Debug:       os.Getenv("DEBUG") != "",
 	}
 	fc, err := falcon.NewClient(config)
 	if err != nil {
-		err0 := fmt.Errorf("failed to create falcon client with error: %s", err)
-		logger.Error(err0)
-		return nil, err0
+		return nil, fmt.Errorf("failed to create falcon client with error: %w", err)
 	}
 	return fc, nil
 }
 
-func newSearchClient(fc *client.CrowdStrikeAPISpecification) searchc.SearchC {
+func newSearchClient(logger *slog.Logger, fc *client.CrowdStrikeAPISpecification) searchc.SearchC {
 	return searchc.NewClient(fc.SavedSearches, logger)
 }
 
-func newStorageClient(fc *client.CrowdStrikeAPISpecification, token string) storagec.StorageC {
+func newStorageClient(fc *client.CrowdStrikeAPISpecification, logger *slog.Logger, token string) storagec.StorageC {
 	hc := http.DefaultClient
 	hc.Timeout = 10 * time.Second
 	return storagec.NewClient(fc.CustomStorage, hc, token, logger)
 }
 
-func newExecutionsProcessor(ctx context.Context, token string) (*processor.ExecutionsProcessor, error) {
-	fc, err := newFalconClient(ctx, token)
+func newExecutionsProcessor(ctx context.Context, logger *slog.Logger, falconCloud falcon.CloudType, token string) (*processor.ExecutionsProcessor, error) {
+	fc, err := newFalconClient(ctx, falconCloud, token)
 	if err != nil {
 		return nil, err
 	}
-	strg := newStorageClient(fc, token)
+	strg := newStorageClient(fc, logger, token)
 	return processor.NewExecutionsProcessor(strg, logger), nil
 }
 
-func newUpsertProcessor(ctx context.Context, token string) (*processor.UpsertProcessor, error) {
-	fc, err := newFalconClient(ctx, token)
+func newUpsertProcessor(ctx context.Context, logger *slog.Logger, falconCloud falcon.CloudType, falconHost, token string) (*processor.UpsertProcessor, error) {
+	fc, err := newFalconClient(ctx, falconCloud, token)
 	if err != nil {
 		return nil, err
 	}
-	srchc := newSearchClient(fc)
-	strgc := newStorageClient(fc, token)
+	srchc := newSearchClient(logger, fc)
+	strgc := newStorageClient(fc, logger, token)
 
 	return processor.NewUpsertProcessor(falconHost, srchc, strgc, logger), nil
 }

--- a/functions/job_history/processor/processor.go
+++ b/functions/job_history/processor/processor.go
@@ -2,14 +2,15 @@ package processor
 
 import (
 	"encoding/json"
+	"log/slog"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/pkg"
-	"github.com/sirupsen/logrus"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
-func jobExecRespJSON(page *paging, j []pkg.JobExecution, e []fdk.APIError, logger logrus.FieldLogger) []byte {
+func jobExecRespJSON(page *paging, j []pkg.JobExecution, e []fdk.APIError, logger *slog.Logger) []byte {
 	if j == nil {
 		j = make([]pkg.JobExecution, 0)
 	}
@@ -19,7 +20,7 @@ func jobExecRespJSON(page *paging, j []pkg.JobExecution, e []fdk.APIError, logge
 	}
 	rJSON, err := json.Marshal(r)
 	if err != nil {
-		logger.Errorf("failed to serialize response: %s", err)
+		logger.Error("failed to serialize response: " + err.Error())
 		return nil
 	}
 	return rJSON

--- a/functions/job_history/processor/processor_executions.go
+++ b/functions/job_history/processor/processor_executions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/url"
@@ -11,21 +12,21 @@ import (
 	"strings"
 	"time"
 
-	fdk "github.com/CrowdStrike/foundry-fn-go"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/pkg"
 	"github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_history/storagec"
-	"github.com/sirupsen/logrus"
+
+	fdk "github.com/CrowdStrike/foundry-fn-go"
 )
 
 // ExecutionsProcessor returns the job execution history.
 type ExecutionsProcessor struct {
-	logger      logrus.FieldLogger
+	logger      *slog.Logger
 	strgc       storagec.StorageC
 	nowProvider func() time.Time
 }
 
 // NewExecutionsProcessor returns a new ExecutionsProcessor instance.
-func NewExecutionsProcessor(strgc storagec.StorageC, logger logrus.FieldLogger, opts ...func(p *ExecutionsProcessor)) *ExecutionsProcessor {
+func NewExecutionsProcessor(strgc storagec.StorageC, logger *slog.Logger, opts ...func(p *ExecutionsProcessor)) *ExecutionsProcessor {
 	p := &ExecutionsProcessor{
 		logger:      logger,
 		strgc:       strgc,
@@ -63,7 +64,7 @@ func (p *ExecutionsProcessor) Process(ctx context.Context, req fdk.Request) Resp
 			}
 		}
 		msg := fmt.Sprintf("failed to fetch all objects: %s", err)
-		p.logger.Errorln(msg)
+		p.logger.Error(msg)
 		return Response{
 			Body: jobExecRespJSON(nil, nil, []fdk.APIError{{Code: http.StatusInternalServerError, Message: msg}}, p.logger),
 			Code: http.StatusInternalServerError,
@@ -73,7 +74,7 @@ func (p *ExecutionsProcessor) Process(ctx context.Context, req fdk.Request) Resp
 
 	jobExecs, err = p.computeDurations(jobExecs)
 	if err != nil {
-		p.logger.Errorf("failed to compute duration for job executions: %s", err)
+		p.logger.Error("failed to compute duration for job executions: " + err.Error())
 	}
 
 	nextPrevOffset, nextNextOffset := p.pagination(filterReq.Offset.Direction, filterReq.Offset.Page, filterReq.Offset.Offset, filterReq.Limit, offset, total)
@@ -91,7 +92,7 @@ func (p *ExecutionsProcessor) Process(ctx context.Context, req fdk.Request) Resp
 	)
 	if resp == nil {
 		msg := "failed to serialize job execution response"
-		p.logger.Errorln(msg)
+		p.logger.Error(msg)
 		return Response{
 			Body: jobExecRespJSON(nil, nil, []fdk.APIError{{Code: http.StatusInternalServerError, Message: msg}}, p.logger),
 			Code: http.StatusInternalServerError,

--- a/functions/job_history/searchc/client.go
+++ b/functions/job_history/searchc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client/saved_searches"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"github.com/eapache/go-resiliency/retrier"
-	"github.com/sirupsen/logrus"
 )
 
 // SearchC represents a search client.
@@ -23,13 +23,13 @@ type SearchC interface {
 // Client is the client.
 type Client struct {
 	c      saved_searches.ClientService
-	logger logrus.FieldLogger
+	logger *slog.Logger
 }
 
 var _ SearchC = (*Client)(nil)
 
 // NewClient returns a new search client.
-func NewClient(c saved_searches.ClientService, logger logrus.FieldLogger) *Client {
+func NewClient(c saved_searches.ClientService, logger *slog.Logger) *Client {
 	return &Client{
 		c:      c,
 		logger: logger,
@@ -45,13 +45,13 @@ func (f *Client) Search(ctx context.Context, req SearchRequest) (SearchResponse,
 		return SearchResponse{}, nil
 	}
 	if req.InitialFetchPause >= 0 {
-		f.logger.Print("pausing to allow job to run")
+		f.logger.Debug("pausing to allow job to run")
 		if req.InitialFetchPause > 0 {
 			time.Sleep(req.InitialFetchPause)
 		} else {
 			time.Sleep(5 * time.Second)
 		}
-		f.logger.Print("waking up to fetch results")
+		f.logger.Debug("waking up to fetch results")
 	}
 
 	resp, err := f.fetchSearchResults(ctx, req, jobID)
@@ -73,7 +73,7 @@ func (f *Client) startSearchJob(ctx context.Context, req SearchRequest) (string,
 	params.IncludeTestData = &boolFalse
 	params.Mode = &mode
 
-	f.logger.Println("starting search")
+	f.logger.Debug("starting search")
 	res, err := f.c.Execute(params)
 	if err != nil {
 		return "", fmt.Errorf("attempting to create search failed: %s", err)
@@ -181,10 +181,8 @@ func (f *Client) fetchSearchResultsCall(ctx context.Context, jobID string, offse
 	params.Limit = &limit
 	params.Offset = &os
 
-	f.logger.WithField("job_id", jobID).
-		WithField("offset", os).
-		WithField("limit", limit).
-		Info("fetching search results")
+	f.logger.Info("fetching search results", "job_id", jobID, "offset", os, "limit", limit)
+
 	resp, err := f.c.Result(params)
 	if err != nil {
 		return savedSearchFetchResource{}, fmt.Errorf("failed to issue HTTP request: %s", err)

--- a/functions/job_history/storagec/client.go
+++ b/functions/job_history/storagec/client.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/crowdstrike/gofalcon/falcon/client/custom_storage"
 	"github.com/crowdstrike/gofalcon/falcon/models"
-	"github.com/sirupsen/logrus"
 )
 
 // NotFound is a dedicated error indicating that the requested object was not found.
@@ -40,13 +40,13 @@ type Client struct {
 	accessToken string
 	c           custom_storage.ClientService
 	hc          *http.Client
-	logger      logrus.FieldLogger
+	logger      *slog.Logger
 }
 
 var _ StorageC = (*Client)(nil)
 
 // NewClient returns a new and initialized instance of a Client.
-func NewClient(c custom_storage.ClientService, hc *http.Client, accessToken string, logger logrus.FieldLogger) *Client {
+func NewClient(c custom_storage.ClientService, hc *http.Client, accessToken string, logger *slog.Logger) *Client {
 	return &Client{
 		accessToken: accessToken,
 		c:           c,
@@ -110,9 +110,8 @@ func (f *Client) FetchObject(ctx context.Context, req FetchObjectRequest) (Fetch
 		ObjectKey:      req.ObjectKey,
 	}
 
-	f.logger.WithField("object_key", params.ObjectKey).
-		WithField("collection", params.CollectionName).
-		Printf("fetching")
+	f.logger.Debug("fetching", "object_key", params.ObjectKey, "collection", params.CollectionName)
+
 	buf := new(bytes.Buffer)
 	resp, err := f.c.GetObject(&params, buf)
 	if resp != nil && resp.IsCode(http.StatusNotFound) {


### PR DESCRIPTION
as we're trying to improve the go sdk we're running into a blocker here with sample apps. These apps are using old patterns and b/c of this, are tangled up in parts we don't want touched directly. This updates it to take advantage of what the SDK offers, removing the need for a lot of boilerplate. Additionally, it frees up the SDK to make the important but technically breaking changes.  None of the other fns hit this, as they're utilizing the SDK helpers instead of creating boilerplate to do it. After this update, we're in the free to update the SDK with this breaking change, that won't actually break anyone. The power of solid helper fns heh