### PR TITLE
chore: upgrade function's go sdk to v0.21.1

### DIFF
--- a/functions/Func_Jobs/go.mod
+++ b/functions/Func_Jobs/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.21.0
+	github.com/CrowdStrike/foundry-fn-go v0.21.1
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/go-openapi/runtime v0.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/functions/job_history/go.mod
+++ b/functions/job_history/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_histor
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.21.0
+	github.com/CrowdStrike/foundry-fn-go v0.21.1
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/eapache/go-resiliency v1.4.0
 	github.com/robfig/cron/v3 v3.0.1


### PR DESCRIPTION
brings in [this fix](https://github.com/CrowdStrike/foundry-fn-go/pull/34)