### PR TITLE
chore: adopt updated go sdk version v0.23.0

### DIFF
--- a/functions/Func_Jobs/api/audit.go
+++ b/functions/Func_Jobs/api/audit.go
@@ -68,7 +68,7 @@ func (h *AuditsHandler) auditDetails(ctx context.Context, request *fdk.Request, 
 		Limit: limit,
 	}
 
-	limitParam := request.Params.Query.Get(queryLimit)
+	limitParam := request.Queries.Get(queryLimit)
 	if limitParam != "" {
 		limit, err = strconv.Atoi(limitParam)
 		if err != nil {
@@ -80,9 +80,9 @@ func (h *AuditsHandler) auditDetails(ctx context.Context, request *fdk.Request, 
 		}
 	}
 
-	nOffset := request.Params.Query.Get(queryPrevOffset)
-	qOffset := request.Params.Query.Get(queryNextOffset)
-	filter := request.Params.Query.Get(queryParamFilter)
+	nOffset := request.Queries.Get(queryPrevOffset)
+	qOffset := request.Queries.Get(queryNextOffset)
+	filter := request.Queries.Get(queryParamFilter)
 
 	if filter != "" {
 		pair := strings.Split(filter, ":")

--- a/functions/Func_Jobs/api/job.go
+++ b/functions/Func_Jobs/api/job.go
@@ -28,13 +28,13 @@ func NewJobHandler(conf *models.Config) *JobHandler {
 
 func (h *JobHandler) Handle(ctx context.Context, request fdk.Request) fdk.Response {
 	response := fdk.Response{}
-	if request.Params.Query == nil {
+	if request.Queries == nil {
 		response.Code = http.StatusBadRequest
 		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: "Request does not have query params"})
 		return response
 	}
 
-	queryParams := request.Params.Query[queryIDParam]
+	queryParams := request.Queries[queryIDParam]
 	if len(queryParams) != 1 {
 		response.Code = http.StatusBadRequest
 		response.Errors = append(response.Errors, fdk.APIError{Code: http.StatusBadRequest, Message: fmt.Sprintf("query params %s length: %d is incorrect", queryIDParam, len(queryIDParam))})

--- a/functions/Func_Jobs/api/job_upsert.go
+++ b/functions/Func_Jobs/api/job_upsert.go
@@ -43,7 +43,7 @@ func (h *UpsertJobHandler) Handle(ctx context.Context, request fdk.Request) fdk.
 		return response
 	}
 
-	queryParams := request.Params.Query.Get(queryIsDraft)
+	queryParams := request.Queries.Get(queryIsDraft)
 	if queryParams == "true" {
 		isDraft = true
 	}

--- a/functions/Func_Jobs/api/jobs.go
+++ b/functions/Func_Jobs/api/jobs.go
@@ -81,7 +81,7 @@ func (h *JobsHandler) jobDetails(ctx context.Context, request *fdk.Request, fc *
 		Limit: limit,
 	}
 
-	limitParam := request.Params.Query.Get(queryLimit)
+	limitParam := request.Queries.Get(queryLimit)
 	if limitParam != "" {
 		limit, err = strconv.Atoi(limitParam)
 		if err != nil {
@@ -93,8 +93,8 @@ func (h *JobsHandler) jobDetails(ctx context.Context, request *fdk.Request, fc *
 		}
 	}
 
-	nOffset := request.Params.Query.Get(queryPrevOffset)
-	qOffset := request.Params.Query.Get(queryNextOffset)
+	nOffset := request.Queries.Get(queryPrevOffset)
+	qOffset := request.Queries.Get(queryNextOffset)
 
 	if qOffset != "" && nOffset != "" {
 		return &response, []fdk.APIError{{

--- a/functions/Func_Jobs/go.mod
+++ b/functions/Func_Jobs/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-rapid-response/functions/Func_Jobs
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.22.0
+	github.com/CrowdStrike/foundry-fn-go v0.23.0
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/go-openapi/runtime v0.26.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/functions/job_history/go.mod
+++ b/functions/job_history/go.mod
@@ -3,7 +3,7 @@ module github.com/Crowdstrike/foundry-sample-rapid-response/functions/job_histor
 go 1.21
 
 require (
-	github.com/CrowdStrike/foundry-fn-go v0.22.0
+	github.com/CrowdStrike/foundry-fn-go v0.23.0
 	github.com/crowdstrike/gofalcon v0.5.0-rc1.0.20231018211136-aa9a14d480c8
 	github.com/eapache/go-resiliency v1.4.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/functions/job_history/processor/processor_executions.go
+++ b/functions/job_history/processor/processor_executions.go
@@ -39,7 +39,7 @@ func NewExecutionsProcessor(strgc storagec.StorageC, logger logrus.FieldLogger, 
 
 // Process returns any job execution histories that match the provided request parameters.
 func (p *ExecutionsProcessor) Process(ctx context.Context, req fdk.Request) Response {
-	queryParams := req.Params.Query
+	queryParams := req.Queries
 	if len(queryParams) == 0 {
 		queryParams = make(url.Values)
 	}


### PR DESCRIPTION
the v0.23.0 flattened the params structure to the root level. We also now have support for queries and headers within the fusion pipeline. This never existed before 2 weeks ago.