### PR TITLE
chore: add host-group read permissions to manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -106,6 +106,7 @@ auth:
         - real-time-response-admin:write
         - devices:read
         - devices:write
+        - host-group:read
         - workflow:write
         - workflow:read
         - usermgmt:read


### PR DESCRIPTION
Users are getting 403s when the trying to retrieve `/entities/group`. This PR adds the `host-group:read` permission