### PR TITLE
Fix rebuild workflow by adding cache-dependency-path

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
+          cache-dependency-path: ui/pages/rapid-response-react/yarn.lock
       - name: Run yarn install
         uses: borales/actions-yarn@v5
         with:


### PR DESCRIPTION
Fixes failure in https://github.com/CrowdStrike/foundry-sample-rapid-response/actions/runs/14458229030/job/40545809606.

```
Error: Dependencies lock file is not found in /home/runner/work/foundry-sample-rapid-response/foundry-sample-rapid-response. Supported file patterns: yarn.lock
``` 