### PR TITLE
Fix Custom Apps submenu retry pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,4 @@ updates:
       - dependency-name: "pnpm/action-setup"
         versions: [">=4.3.0"]
       - dependency-name: "actions/cache"
-        versions: [">=5.1.0"]
+        versions: [">=5.0.4"]

--- a/e2e/src/pages/RapidResponseHomePage.ts
+++ b/e2e/src/pages/RapidResponseHomePage.ts
@@ -369,8 +369,9 @@ export class RapidResponseHomePage extends BasePage {
     await this.navigateToPath('/foundry/home', 'Foundry home page');
     await this.page.waitForLoadState('networkidle');
 
-    // Retry with page refresh if Custom apps menu doesn't appear
-    let customAppsFound = false;
+    // Retry with page refresh if Custom apps menu or app button doesn't appear
+    const appName = config.appName;
+    let appFound = false;
     for (let attempt = 1; attempt <= 5; attempt++) {
       const menuButton = this.page.getByTestId('nav-trigger');
       await menuButton.waitFor({ state: 'visible', timeout: 30000 });
@@ -382,24 +383,41 @@ export class RapidResponseHomePage extends BasePage {
         await customAppsButton.waitFor({ state: 'visible', timeout: 20000 });
         await customAppsButton.click();
         await this.waiter.delay(1500);
-        customAppsFound = true;
         this.logger.info(`Custom apps button found on attempt ${attempt}`);
-        break;
       } catch (e) {
         this.logger.warn(`Custom apps not visible on attempt ${attempt}, refreshing page...`);
         await this.page.reload();
         await this.page.waitForLoadState('networkidle');
         await this.waiter.delay(3000);
+        continue;
+      }
+
+      // Check if the app button appears in the submenu
+      const appButtonCheck = this.page.getByRole('button', { name: appName, exact: false }).first();
+      try {
+        await appButtonCheck.waitFor({ state: 'visible', timeout: 10000 });
+        appFound = true;
+        this.logger.info(`App '${appName}' found in Custom apps menu on attempt ${attempt}`);
+        break;
+      } catch (e) {
+        this.logger.warn(`App '${appName}' not in Custom apps on attempt ${attempt}, refreshing page...`);
+        await this.page.reload();
+        await this.page.waitForLoadState('networkidle');
+        await this.waiter.delay(3000);
       }
     }
-    if (!customAppsFound) {
-      throw new Error('Custom apps button not found after 5 attempts with page refresh');
+    if (!appFound) {
+      throw new Error(`App '${appName}' not found in Custom apps menu after 5 attempts with page refresh`);
     }
 
-    const appName = config.appName;
+    // Expand the app menu only if not already expanded
     const appButton = this.page.getByRole('button', { name: appName, exact: false }).first();
-
-    await expect(appButton).toBeVisible({ timeout: 20000 });
+    await expect(appButton).toBeVisible({ timeout: 10000 });
+    const isExpanded = await appButton.getAttribute('aria-expanded');
+    if (isExpanded !== 'true') {
+      await appButton.click();
+      await this.waiter.delay(500);
+    }
 
     // Click the app link
     const appLinks = this.page.getByRole('link').filter({ hasText: /all jobs|rapid response/i });


### PR DESCRIPTION
The retry loop in `navigateViaCustomApps()` only retried finding the "Custom apps" button, but not the app within the submenu. The Falcon console sidebar sometimes loads without listing all installed apps. This caused intermittent e2e test failures.

Now the retry loop covers both levels: finding the "Custom apps" button AND finding the app within the submenu. Also adds an `aria-expanded` check before clicking to avoid collapsing an already-expanded menu.

Pattern ported from foundry-sample-logscale which already had this fix.