### PR TITLE
Fix null body crash on Run History/Audit Log and tighten e2e assertions

### DIFF
--- a/e2e/src/pages/AllJobsPage.ts
+++ b/e2e/src/pages/AllJobsPage.ts
@@ -19,8 +19,7 @@ export class AllJobsPage extends BasePage {
     // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
 
-    // Look for Create Job button or job list container
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
     const jobsContainer = frame.locator('[class*="job"]').or(frame.locator('table'));
 
     if (
@@ -39,10 +38,9 @@ export class AllJobsPage extends BasePage {
   async hasCreateJobButton(): Promise<boolean> {
     this.logger.step('Check for Create Job button');
 
-    // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
-    const exists = await this.elementExists(createJobButton, 3000);
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
+    const exists = await this.elementExists(createJobButton, 10000);
 
     this.logger.info(`Create Job button ${exists ? 'found' : 'not found'}`);
     return exists;
@@ -54,9 +52,8 @@ export class AllJobsPage extends BasePage {
   async clickCreateJob(): Promise<void> {
     this.logger.step('Click Create Job button');
 
-    // The app content is in an iframe
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const createJobButton = frame.locator('button', { hasText: /create job/i });
+    const createJobButton = frame.locator('a', { hasText: /create job/i });
     await createJobButton.click();
     await this.waiter.delay(1000);
 
@@ -78,19 +75,16 @@ export class AllJobsPage extends BasePage {
     return count > 0;
   }
 
-  /**
-   * Verify page renders correctly
-   */
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify All Jobs page renders');
 
-    // Check for main page elements
+    const frame = this.page.frameLocator('iframe[name="portal"]').first();
+    const heading = frame.locator('h1', { hasText: /all jobs/i });
+    const hasHeading = await this.elementExists(heading, 10000);
     const hasButton = await this.hasCreateJobButton();
-    const url = this.getCurrentUrl();
-    const hasCorrectUrl = url.includes('all-jobs') || url.includes('path=%2F');
 
-    const renders = hasButton || hasCorrectUrl;
-    this.logger.info(`All Jobs page renders: ${renders}`);
+    const renders = hasHeading && hasButton;
+    this.logger.info(`All Jobs page renders: ${renders} (heading: ${hasHeading}, button: ${hasButton})`);
 
     return renders;
   }

--- a/e2e/src/pages/AuditLogPage.ts
+++ b/e2e/src/pages/AuditLogPage.ts
@@ -64,17 +64,20 @@ export class AuditLogPage extends BasePage {
   }
 
   /**
-   * Verify page renders correctly
+   * Verify page renders correctly by checking for the "Audit log" heading
+   * or a table inside the page content area (not just the nav tab).
    */
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify Audit Log page renders');
 
-    // Check for presence of "Audit log" tab being active or visible content
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const auditLogText = frame.locator('text="Audit log"');
-    const hasContent = await this.elementExists(auditLogText, 3000);
+    const heading = frame.locator('h1', { hasText: /audit log/i });
+    const table = frame.locator('table');
+    const hasHeading = await this.elementExists(heading, 10000);
+    const hasTable = await this.elementExists(table, 3000);
 
-    this.logger.info(`Audit Log page renders: ${hasContent}`);
-    return hasContent;
+    const renders = hasHeading || hasTable;
+    this.logger.info(`Audit Log page renders: ${renders} (heading: ${hasHeading}, table: ${hasTable})`);
+    return renders;
   }
 }

--- a/e2e/src/pages/RunHistoryPage.ts
+++ b/e2e/src/pages/RunHistoryPage.ts
@@ -64,17 +64,20 @@ export class RunHistoryPage extends BasePage {
   }
 
   /**
-   * Verify page renders correctly
+   * Verify page renders correctly by checking for the "Run history" heading
+   * or a table inside the page content area (not just the nav tab).
    */
   async verifyPageRenders(): Promise<boolean> {
     this.logger.step('Verify Run History page renders');
 
-    // Check for presence of "Run history" tab being active or visible content
     const frame = this.page.frameLocator('iframe[name="portal"]').first();
-    const runHistoryText = frame.locator('text="Run history"');
-    const hasContent = await this.elementExists(runHistoryText, 3000);
+    const heading = frame.locator('h1', { hasText: /run history/i });
+    const table = frame.locator('table');
+    const hasHeading = await this.elementExists(heading, 10000);
+    const hasTable = await this.elementExists(table, 3000);
 
-    this.logger.info(`Run History page renders: ${hasContent}`);
-    return hasContent;
+    const renders = hasHeading || hasTable;
+    this.logger.info(`Run History page renders: ${renders} (heading: ${hasHeading}, table: ${hasTable})`);
+    return renders;
   }
 }

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -67,9 +67,9 @@ test.describe('Rapid Response App E2E Tests', () => {
     const renders = await allJobsPage.verifyPageRenders();
     expect(renders).toBeTruthy();
 
-    // Check for Create Job button
+    // Verify Create Job button is present
     const hasButton = await allJobsPage.hasCreateJobButton();
-    console.log(`Create Job button present: ${hasButton}`);
+    expect(hasButton).toBeTruthy();
 
     console.log('✅ All Jobs page verified');
   });
@@ -93,7 +93,6 @@ test.describe('Rapid Response App E2E Tests', () => {
     const renders = await runHistoryPage.verifyPageRenders();
     expect(renders).toBeTruthy();
 
-    // Check for history table
     const hasTable = await runHistoryPage.hasHistoryTable();
     console.log(`History table present: ${hasTable}`);
 
@@ -119,7 +118,6 @@ test.describe('Rapid Response App E2E Tests', () => {
     const renders = await auditLogPage.verifyPageRenders();
     expect(renders).toBeTruthy();
 
-    // Check for audit table
     const hasTable = await auditLogPage.hasAuditTable();
     console.log(`Audit log table present: ${hasTable}`);
 
@@ -139,25 +137,16 @@ test.describe('Rapid Response App E2E Tests', () => {
     await rapidResponseHomePage.navigateToInstalledApp();
     await rapidResponseHomePage.navigateToAllJobs();
 
-    // Check if Create Job button exists
+    // Verify Create Job button exists
     const hasButton = await allJobsPage.hasCreateJobButton();
+    expect(hasButton).toBeTruthy();
 
-    if (hasButton) {
-      // Try clicking it to see if wizard opens
-      await allJobsPage.clickCreateJob();
+    // Click it and verify the form opens
+    await allJobsPage.clickCreateJob();
+    await allJobsPage.waiter.delay(1000);
 
-      // Wait a moment for any navigation/modal to appear
-      await allJobsPage.waiter.delay(1000);
-
-      // Check URL changed or modal appeared
-      const url = allJobsPage.getCurrentUrl();
-      const hasCreateJobUrl = url.includes('create-job');
-
-      console.log(`Create Job form accessible: ${hasCreateJobUrl}`);
-      expect(hasButton).toBeTruthy();
-    } else {
-      console.log('ℹ️  Create Job button not found (may be permission-based)');
-    }
+    const url = allJobsPage.getCurrentUrl();
+    console.log(`Create Job form accessible: ${url.includes('create-job')}`);
 
     console.log('✅ Create Job button accessibility verified');
   });

--- a/ui/pages/rapid-response-react/src/lib/validations/api-validation.ts
+++ b/ui/pages/rapid-response-react/src/lib/validations/api-validation.ts
@@ -241,13 +241,15 @@ export const RunHistorySchema = z.object({
 export type RunHistory = z.infer<typeof RunHistorySchema>;
 
 export const runHistoryDataSchema = z.object({
-  body: z.object({
-    resources: z
-      .array(RunHistorySchema)
-      .nullable()
-      .transform((val) => val ?? []),
-    meta: MetaSchema,
-  }),
+  body: z
+    .object({
+      resources: z
+        .array(RunHistorySchema)
+        .nullable()
+        .transform((val) => val ?? []),
+      meta: MetaSchema,
+    })
+    .nullable(),
 });
 
 export const AuditLogSchema = z.object({
@@ -263,13 +265,15 @@ export const AuditLogSchema = z.object({
 export type AuditLogType = z.infer<typeof AuditLogSchema>;
 
 export const auditLogDataSchema = z.object({
-  body: z.object({
-    resources: z
-      .array(AuditLogSchema)
-      .nullable()
-      .transform((val) => val ?? []),
-    meta: MetaSchema,
-  }),
+  body: z
+    .object({
+      resources: z
+        .array(AuditLogSchema)
+        .nullable()
+        .transform((val) => val ?? []),
+      meta: MetaSchema,
+    })
+    .nullable(),
 });
 
 export const jobDataSchema = z.object({

--- a/ui/pages/rapid-response-react/src/pages/AuditLog.tsx
+++ b/ui/pages/rapid-response-react/src/pages/AuditLog.tsx
@@ -39,9 +39,11 @@ export const loader: Loader = ({ falcon }) => {
     });
     const result = auditLogDataSchema.parse(rawResult);
 
-    result.body.meta.offset = result.body.resources?.[0]?.id ?? "";
-    // Add a computed page number to render the pagination data
-    result.body.meta.page = page;
+    if (result.body) {
+      result.body.meta.offset = result.body.resources?.[0]?.id ?? "";
+      // Add a computed page number to render the pagination data
+      result.body.meta.page = page;
+    }
 
     return result;
   };
@@ -50,7 +52,11 @@ export const loader: Loader = ({ falcon }) => {
 function AuditLog() {
   const data = useParsedLoaderData<AuditLogDataSchema>(auditLogDataSchema);
 
-  if (data.body.meta.total === 0) {
+  if (data.body?.meta.total === 0) {
+    return <NoAuditLogs />;
+  }
+
+  if (!data.body) {
     return <NoAuditLogs />;
   }
 

--- a/ui/pages/rapid-response-react/src/pages/JobDetails.tsx
+++ b/ui/pages/rapid-response-react/src/pages/JobDetails.tsx
@@ -77,21 +77,21 @@ function JobDetails() {
   );
   const historyTableData = useMemo(
     () =>
-      mapJobHistoryDetailsToTableData(data.history.body.resources, {
+      mapJobHistoryDetailsToTableData(data.history.body?.resources ?? [], {
         timezone,
         locale,
         dateFormat,
       }),
-    [data.history.body.resources, timezone, locale, dateFormat],
+    [data.history.body?.resources, timezone, locale, dateFormat],
   );
   const auditLogTableData = useMemo(
     () =>
-      mapAuditLogDetailsToTableData(data.auditLogs.body.resources, {
+      mapAuditLogDetailsToTableData(data.auditLogs.body?.resources ?? [], {
         timezone,
         locale,
         dateFormat,
       }),
-    [data.auditLogs.body.resources, timezone, locale, dateFormat],
+    [data.auditLogs.body?.resources, timezone, locale, dateFormat],
   );
 
   return (

--- a/ui/pages/rapid-response-react/src/pages/RunHistory.tsx
+++ b/ui/pages/rapid-response-react/src/pages/RunHistory.tsx
@@ -51,10 +51,12 @@ export const loader: Loader = ({ falcon }) => {
     });
     const safeResult = runHistoryDataSchema.parse(result);
 
-    safeResult.body.meta.offset =
-      safeResult.body.resources?.[0]?.execution_id ?? "";
-    // Add a computed page number to render the pagination information
-    safeResult.body.meta.page = page;
+    if (safeResult.body) {
+      safeResult.body.meta.offset =
+        safeResult.body.resources?.[0]?.execution_id ?? "";
+      // Add a computed page number to render the pagination information
+      safeResult.body.meta.page = page;
+    }
 
     return safeResult;
   };
@@ -71,7 +73,11 @@ function RunHistory() {
    */
   const [activeHostsOnDrawer, setActiveHostsForDrawer] = useState<string[]>([]);
 
-  if (data.body.meta.total === 0 && !hasActiveFilters) {
+  if (data.body?.meta.total === 0 && !hasActiveFilters) {
+    return <NoRuns />;
+  }
+
+  if (!data.body) {
     return <NoRuns />;
   }
 


### PR DESCRIPTION
The Run History and Audit Log pages crash with "An error has happened" when cloud functions return responses without a `body` field (e.g., when no job executions or audit log entries exist). The root cause is that `runHistoryDataSchema` and `auditLogDataSchema` in `api-validation.ts` require a non-nullable `body`, so Zod's `.parse()` throws when `body` is null or missing. The `allJobsDataSchema` already handles this correctly with `.nullable()`.

This adds `.nullable()` to both schemas, adds null body checks in the route loaders and components, and uses optional chaining in `JobDetails.tsx` for history/auditLog body access.

Also tightens e2e test assertions that were silently passing without verifying page content actually rendered.

Fixes #333