### PR TITLE
Fix CVE: upgrade vite to 7.3.2

### DIFF
--- a/ui/pages/rapid-response-react/package.json
+++ b/ui/pages/rapid-response-react/package.json
@@ -49,7 +49,7 @@
     "rollup-plugin-visualizer": "6.0.3",
     "tailwindcss": "3.3.3",
     "typescript": "5.8.3",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vitest": "3.2.4"
   },
   "resolutions": {

--- a/ui/pages/rapid-response-react/pnpm-lock.yaml
+++ b/ui/pages/rapid-response-react/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 8.50.1(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: 5.0.2
-        version: 5.0.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))
+        version: 5.0.2(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))
       '@vitest/eslint-plugin':
         specifier: 1.4.3
         version: 1.4.3(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)(vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3))
@@ -129,8 +129,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vite:
-        specifier: 7.3.1
-        version: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+        specifier: 7.3.2
+        version: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
       vitest:
         specifier: 3.2.4
         version: 3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3)
@@ -2522,8 +2522,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3433,7 +3433,7 @@ snapshots:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.0.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.0.2(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -3441,7 +3441,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.34
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3464,13 +3464,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5281,7 +5281,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5296,7 +5296,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(jiti@1.21.7)(yaml@2.8.3):
+  vite@7.3.2(jiti@1.21.7)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5313,7 +5313,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5331,7 +5331,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
       vite-node: 3.2.4(jiti@1.21.7)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
Upgrades vite from 7.3.1 to 7.3.2, fixing SSRF and XSS vulnerabilities. Dist rebuilt. Tests pass.