### PR TITLE
Upgrade vite 7.3.1→7.3.2 and postcss 8.5.6→8.5.14

### DIFF
--- a/ui/pages/rapid-response-react/package.json
+++ b/ui/pages/rapid-response-react/package.json
@@ -44,12 +44,12 @@
     "eslint-plugin-react-refresh": "0.4.20",
     "globals": "17.1.0",
     "jsdom": "27.0.0",
-    "postcss": "8.5.6",
+    "postcss": "8.5.14",
     "prettier": "3.6.2",
     "rollup-plugin-visualizer": "6.0.3",
     "tailwindcss": "3.3.3",
     "typescript": "5.8.3",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vitest": "3.2.4"
   },
   "resolutions": {

--- a/ui/pages/rapid-response-react/pnpm-lock.yaml
+++ b/ui/pages/rapid-response-react/pnpm-lock.yaml
@@ -82,13 +82,13 @@ importers:
         version: 8.50.1(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: 5.0.2
-        version: 5.0.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))
+        version: 5.0.2(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))
       '@vitest/eslint-plugin':
         specifier: 1.4.3
-        version: 1.4.3(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)(vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3))
+        version: 1.4.3(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)(vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.14))(yaml@2.8.3))
       autoprefixer:
         specifier: 10.4.21
-        version: 10.4.21(postcss@8.5.6)
+        version: 10.4.21(postcss@8.5.14)
       eslint:
         specifier: 9.35.0
         version: 9.35.0(jiti@1.21.7)
@@ -112,10 +112,10 @@ importers:
         version: 17.1.0
       jsdom:
         specifier: 27.0.0
-        version: 27.0.0(postcss@8.5.6)
+        version: 27.0.0(postcss@8.5.14)
       postcss:
-        specifier: 8.5.6
-        version: 8.5.6
+        specifier: 8.5.14
+        version: 8.5.14
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -129,11 +129,11 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vite:
-        specifier: 7.3.1
-        version: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+        specifier: 7.3.2
+        version: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3)
+        version: 3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.14))(yaml@2.8.3)
 
 packages:
 
@@ -2070,8 +2070,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2522,8 +2522,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2855,9 +2855,9 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.14)':
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.14
 
   '@csstools/css-tokenizer@3.0.4': {}
 
@@ -3433,7 +3433,7 @@ snapshots:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.0.2(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.0.2(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -3441,18 +3441,18 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.34
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.4.3(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)(vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3))':
+  '@vitest/eslint-plugin@1.4.3(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)(vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.14))(yaml@2.8.3))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.51.0
       '@typescript-eslint/utils': 8.51.0(eslint@9.35.0(jiti@1.21.7))(typescript@5.8.3)
       eslint: 9.35.0(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3)
+      vitest: 3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.14))(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3464,13 +3464,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3605,14 +3605,14 @@ snapshots:
 
   async-generator-function@1.0.0: {}
 
-  autoprefixer@10.4.21(postcss@8.5.6):
+  autoprefixer@10.4.21(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001766
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -3757,10 +3757,10 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssstyle@5.3.0(postcss@8.5.6):
+  cssstyle@5.3.0(postcss@8.5.14):
     dependencies:
       '@asamuzakjp/css-color': 4.1.1
-      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.14)
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
@@ -4448,10 +4448,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.0.0(postcss@8.5.6):
+  jsdom@27.0.0(postcss@8.5.14):
     dependencies:
       '@asamuzakjp/dom-selector': 6.5.4
-      cssstyle: 5.3.0(postcss@8.5.6)
+      cssstyle: 5.3.0(postcss@8.5.14)
       data-urls: 6.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
@@ -4705,28 +4705,28 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.14):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.14
 
-  postcss-load-config@4.0.2(postcss@8.5.6):
+  postcss-load-config@4.0.2(postcss@8.5.14):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.14
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -4736,7 +4736,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5141,11 +5141,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 4.0.2(postcss@8.5.14)
+      postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -5281,7 +5281,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5296,12 +5296,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(jiti@1.21.7)(yaml@2.8.3):
+  vite@7.3.2(jiti@1.21.7)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.14
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -5309,11 +5309,11 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.8.3
 
-  vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.3):
+  vitest@3.2.4(jiti@1.21.7)(jsdom@27.0.0(postcss@8.5.14))(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(jiti@1.21.7)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(jiti@1.21.7)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5331,11 +5331,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(jiti@1.21.7)(yaml@2.8.3)
+      vite: 7.3.2(jiti@1.21.7)(yaml@2.8.3)
       vite-node: 3.2.4(jiti@1.21.7)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      jsdom: 27.0.0(postcss@8.5.6)
+      jsdom: 27.0.0(postcss@8.5.14)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
Fixes CVE-2026-39363, CVE-2026-39364, CVE-2026-39365 (Vite) and CVE-2026-41305 (PostCSS).

All tests and linting pass. Build output unchanged.