### PR TITLE
Remove redundant corepack enable from rebuild workflow

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -35,9 +35,6 @@ jobs:
             echo "Dependency changes detected:"
             echo "$CHANGES"
           fi
-      - name: Enable Corepack
-        if: steps.check.outputs.skip != 'true'
-        run: corepack enable
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         if: steps.check.outputs.skip != 'true'
         with:


### PR DESCRIPTION
The rebuild workflow already installs pnpm through `pnpm/action-setup`, so the `corepack enable` step above it does nothing. This removes it.

The pnpm team [recommends against using corepack](https://x.com/pnpmjs/status/2087964982289854928) to install pnpm. The Node.js TSC has also voted to stop bundling corepack, though it still ships as of Node 26, so this is cleanup rather than anything urgent.